### PR TITLE
Namespace top-level generated functions to prevent stomping

### DIFF
--- a/pyplusplus/file_writers/multiple_files.py
+++ b/pyplusplus/file_writers/multiple_files.py
@@ -253,7 +253,7 @@ class multiple_files_t(writer.writer_t):
         return os.linesep.join( answer )
 
     def split_class_impl( self, class_creator):
-        function_name = 'register_%s_class' % class_creator.alias
+        function_name = 'register_' + self.extmodule.body.name + '_%s_class' % class_creator.alias
         file_path = os.path.join( self.directory_path, class_creator.alias )
         # Write the .h file...
         header_name = file_path + self.HEADER_EXT
@@ -359,21 +359,21 @@ class multiple_files_t(writer.writer_t):
         """
         enums_creators = [x for x in self.extmodule.body.creators if isinstance(x, code_creators.enum_t )]
 
-        self.split_creators( enums_creators, '_enumerations', 'register_enumerations', 0 )
+        self.split_creators( enums_creators, '_enumerations', 'register_' + self.extmodule.body.name + '_enumerations', 0 )
 
     def split_global_variables( self ):
         """Write all global variables into a separate .h/.cpp file.
         """
         creators = [x for x in self.extmodule.body.creators if isinstance(x, code_creators.global_variable_t )]
         creators.extend( [x for x in self.extmodule.body.creators if isinstance(x, code_creators.unnamed_enum_t )] )
-        self.split_creators( creators, '_global_variables', 'register_global_variables', -1 )
+        self.split_creators( creators, '_global_variables', 'register_' + self.extmodule.body.name + '_global_variables', -1 )
 
     def split_free_functions( self ):
         """Write all free functions into a separate .h/.cpp file.
         """
         free_functions = ( code_creators.free_function_t, code_creators.free_fun_overloads_t )
         creators = [x for x in self.extmodule.body.creators if isinstance(x, free_functions )]
-        self.split_creators( creators, '_free_functions', 'register_free_functions', -1 )
+        self.split_creators( creators, '_free_functions', 'register_' + self.extmodule.body.name + '_free_functions', -1 )
 
     def write(self):
         """


### PR DESCRIPTION
In the generated binding code, many top-level functions are generated with the name `register_free_functions`, etc. On MacOS, these functions seem to stomp on each other when linked together.

This causes, for example, the `base` module to call the `util` module's `register_free_functions` (maybe since it was the last one linked alphabetically?) rather than its own, which means that the wrong types and functions show up in the wrong modules, or show up multiple times.

This PR names these top-level functions according to their module, so `register_free_functions` becomes `register__base_free_functions`, `register__util_free_functions`, etc.

This can also happen for classes with the same name in multiple modules, ex. `PlannerDataStorage`. We prefix `register_PlannerDataStorage` as `register__base_PlannerDataStorage` and `register__control_PlannerDataStorage`.

This fixes issues in the OMPL Python bindings like `ompl.base.plannerOrTerminationCondition` not existing, or multiple incompatible versions of `ompl.util.LogLevel` being registered in the same dynamic library.